### PR TITLE
Filter out null fields when generating schemas, these only belong in migrations

### DIFF
--- a/lib/ex_oauth2_provider/schema.ex
+++ b/lib/ex_oauth2_provider/schema.ex
@@ -19,6 +19,7 @@ defmodule ExOauth2Provider.Schema do
           field(name, type)
 
         {name, type, defaults} ->
+          defaults = Enum.reject(defaults, fn {k, _} -> k == :null end)
           field(name, type, defaults)
       end)
 


### PR DESCRIPTION
Ecto checks for fields that do not belong in schema's now, instead of silently ignoring them.
https://elixirforum.com/t/ecto-schema-argumenterror-invalid-option-null-for-field-3/49631/2