### PR TITLE
Always regenerate a new token on valid client credentials

### DIFF
--- a/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
+++ b/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
@@ -120,7 +120,7 @@ defmodule ExOauth2Provider.AccessTokens do
 
     queryable
     |> where([a], is_nil(a.revoked_at))
-    |> where([a], is_nil(a.expires_in) or datetime_add(a.inserted_at, a.expires_in, "second") > ^now)
+    |> where([a], is_nil(a.expires_in) or datetime_add(a.inserted_at, a.expires_in, "second") > datetime_add(^now, 5, "minute"))
     |> order_by([a], desc: a.inserted_at, desc: :id)
     |> Config.repo(config).all()
     |> Enum.filter(&is_accessible?/1)

--- a/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
+++ b/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
@@ -90,26 +90,6 @@ defmodule ExOauth2Provider.AccessTokens do
     |> load_matching_token_for(application, scopes, config)
   end
 
-  @doc """
-  Gets the most recent, acccessible, matching access token for an application.
-
-  ## Examples
-
-      iex> get_application_token_for(application, "read write", otp_app: :my_app)
-      %OauthAccessToken{}
-
-      iex> get_application_token_for(application, "read invalid", otp_app: :my_app)
-      nil
-  """
-  @spec get_application_token_for(Application.t(), binary(), keyword()) :: AccessToken.t() | nil
-  def get_application_token_for(application, scopes, config \\ []) do
-    config
-    |> Config.access_token()
-    |> scope_belongs_to(:resource_owner_id, nil)
-    |> scope_belongs_to(:application_id, application)
-    |> load_matching_token_for(application, scopes, config)
-  end
-
   defp load_matching_token_for(queryable, application, scopes, config) do
     now =
       config
@@ -120,7 +100,7 @@ defmodule ExOauth2Provider.AccessTokens do
 
     queryable
     |> where([a], is_nil(a.revoked_at))
-    |> where([a], is_nil(a.expires_in) or datetime_add(a.inserted_at, a.expires_in, "second") > datetime_add(^now, 5, "minute"))
+    |> where([a], is_nil(a.expires_in) or datetime_add(a.inserted_at, a.expires_in, "second") > ^now)
     |> order_by([a], desc: a.inserted_at, desc: :id)
     |> Config.repo(config).all()
     |> Enum.filter(&is_accessible?/1)

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/client_credentials.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/client_credentials.ex
@@ -38,13 +38,7 @@ defmodule ExOauth2Provider.Token.ClientCredentials do
       scopes: scopes
     }
 
-    application
-    |> AccessTokens.get_application_token_for(scopes, config)
-    |> case do
-      nil          -> AccessTokens.create_application_token(application, token_params, config)
-      access_token -> {:ok, access_token}
-    end
-    |> case do
+    case AccessTokens.create_application_token(application, token_params, config) do
       {:ok, access_token} -> {:ok, Map.merge(params, %{access_token: access_token})}
       {:error, error}     -> Error.add_error({:ok, params}, error)
     end

--- a/test/ex_oauth2_provider/access_tokens/access_tokens_test.exs
+++ b/test/ex_oauth2_provider/access_tokens/access_tokens_test.exs
@@ -128,6 +128,17 @@ defmodule ExOauth2Provider.AccessTokensTest do
 
       refute AccessTokens.get_application_token_for(Fixtures.application(uid: "application-2"), nil, otp_app: :ex_oauth2_provider)
     end
+
+    test "does not get the token when it expires within 5 minutes", %{application: application} do
+      {:ok, %{expires_in: expires_in} = access_token} =
+        AccessTokens.create_application_token(application, %{}, otp_app: :ex_oauth2_provider)
+
+      inserted_at = QueryHelpers.timestamp(OauthAccessToken, :inserted_at, seconds: -1 * expires_in + 299)
+      # the token will expire in 4min 59s
+      QueryHelpers.change!(access_token, inserted_at: inserted_at)
+
+      refute AccessTokens.get_application_token_for(application, nil, otp_app: :ex_oauth2_provider)
+    end
   end
 
   test "get_authorized_tokens_for/2", %{user: user, application: application} do

--- a/test/ex_oauth2_provider/access_tokens/access_tokens_test.exs
+++ b/test/ex_oauth2_provider/access_tokens/access_tokens_test.exs
@@ -116,31 +116,6 @@ defmodule ExOauth2Provider.AccessTokensTest do
     end
   end
 
-  describe "get_application_token_for/3" do
-    test "fetches", %{application: application} do
-      {:ok, access_token1} = AccessTokens.create_application_token(application, %{}, otp_app: :ex_oauth2_provider)
-      inserted_at = QueryHelpers.timestamp(OauthAccessToken, :inserted_at, seconds: -1)
-      QueryHelpers.change!(access_token1, inserted_at: inserted_at)
-      {:ok, access_token2} = AccessTokens.create_application_token(application, %{}, otp_app: :ex_oauth2_provider)
-
-      assert %OauthAccessToken{id: id} = AccessTokens.get_application_token_for(application, nil, otp_app: :ex_oauth2_provider)
-      assert id == access_token2.id
-
-      refute AccessTokens.get_application_token_for(Fixtures.application(uid: "application-2"), nil, otp_app: :ex_oauth2_provider)
-    end
-
-    test "does not get the token when it expires within 5 minutes", %{application: application} do
-      {:ok, %{expires_in: expires_in} = access_token} =
-        AccessTokens.create_application_token(application, %{}, otp_app: :ex_oauth2_provider)
-
-      inserted_at = QueryHelpers.timestamp(OauthAccessToken, :inserted_at, seconds: -1 * expires_in + 299)
-      # the token will expire in 4min 59s
-      QueryHelpers.change!(access_token, inserted_at: inserted_at)
-
-      refute AccessTokens.get_application_token_for(application, nil, otp_app: :ex_oauth2_provider)
-    end
-  end
-
   test "get_authorized_tokens_for/2", %{user: user, application: application} do
     {:ok, access_token} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
 


### PR DESCRIPTION
So we got this scenario where a client calls our API every 24hrs and calls the token endpoint first every time. Now this token endpoint will just return the currently valid token. But seeing as this token is valid for exactly 24hrs he now sometimes ends up with an invalid token for his request.
I changed the behavior to have the endpoint ~~only return a currently valid access token when it does not expire within the next 5 minutes.~~ always generate a new token on valid client credentials.
